### PR TITLE
Update and Fix `truckersmp-cli`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712449641,
-        "narHash": "sha256-U9DDWMexN6o5Td2DznEgguh8TRIUnIl9levmit43GcI=",
+        "lastModified": 1731245184,
+        "narHash": "sha256-vmLS8+x+gHRv1yzj3n+GTAEObwmhxmkkukB2DwtJRdU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "600b15aea1b36eeb43833a50b0e96579147099ff",
+        "rev": "aebe249544837ce42588aa4b2e7972222ba12e8f",
         "type": "github"
       },
       "original": {

--- a/pkgs/truckersmp-cli/default.nix
+++ b/pkgs/truckersmp-cli/default.nix
@@ -17,8 +17,8 @@ let
   src = fetchFromGitHub {
     repo = "truckersmp-cli";
     owner = "truckersmp-cli";
-    rev = "6ab26a81d4d45b44db790b866f29e3f59edb6ae5";
-    sha256 = "sha256-339v9YUdDH7vSa4ktFdXqsHiStyuhARYmOoVqyKurII=";
+    rev = "a50d9c06d19a4f7ef393a70611c91d4e7cf9a86e";
+    sha256 = "sha256-BeSPmcbK5GTUWlT3Fhm0MDfA0Go8JlCxl/PHgUN3sX0=";
   };
 
   postPatch = ''
@@ -49,7 +49,7 @@ let
 in 
   pkgs.buildFHSEnv {
     pname = "truckersmp-cli";
-    version = "0.10.2";
+    version = "0.10.2.1";
     targetPkgs = pkgs: [ truckersmp-cli ];
     runScript = "truckersmp-cli";
 

--- a/pkgs/truckersmp-cli/default.nix
+++ b/pkgs/truckersmp-cli/default.nix
@@ -3,8 +3,7 @@
 , fetchFromGitHub
 , python312Packages
 , SDL2
-, steamPackages
-, steam-run-native
+, steamcmd
 , pkgsCross}:
 
 
@@ -27,7 +26,7 @@ let
 
     substituteInPlace truckersmp_cli/steamcmd.py --replace \
       'steamcmd_path = os.path.join(Dir.steamcmddir, "steamcmd.sh")' \
-      'steamcmd_path = "${steamPackages.steamcmd}/bin/steamcmd"'
+      'steamcmd_path = "${steamcmd}/bin/steamcmd"'
 
     substituteInPlace truckersmp_cli/utils.py --replace \
       '"""Download files."""' 'print(files_to_download)'
@@ -41,7 +40,7 @@ let
 
   nativeBuildInputs = [ pkgsCross.mingwW64.buildPackages.gcc ];
 
-  buildInputs = [ SDL2 steamPackages.steamcmd steamPackages.steam-runtime];
+  buildInputs = [ SDL2 steamcmd ];
 
   propagatedBuildInputs = with python312Packages; [ vdf ];
 


### PR DESCRIPTION
Unstable nixpkgs made changes to `steamcmd` and `steam-runtime`, the latter of which no longer exists.

This pull request fixes the above issue, as well as:
- Updates the Lock File
- Updates the package to `0.10.2.1`, though the update seems rather useless.

These changes have been tested on my own machine and have worked without issue.